### PR TITLE
Fix for latest CryptoCompare HistoricalPrice API

### DIFF
--- a/src/CryptoCompare/Clients/IPricesClient.cs
+++ b/src/CryptoCompare/Clients/IPricesClient.cs
@@ -40,7 +40,7 @@ namespace CryptoCompare
             DateTimeOffset requestedDate,
             CalculationType? calculationType = null,
             bool? tryConversion = null,
-            string exchangeName = null);
+            IEnumerable<string> markets = null);
 
         /// <summary>
         /// Same as single API path but with multiple from symbols.
@@ -81,7 +81,7 @@ namespace CryptoCompare
         /// <param name="fromSymbol">from symbol.</param>
         /// <param name="toSymbols">to symbols.</param>
         /// <param name="tryConversion">If set to false, it will try to get values without using any conversion at all (defaultVal:true)</param>
-        /// <param name="exchangeName">Exchange name defult => CCCAGG</param>
+        /// <param name="exchangeName">Exchange name default => CCCAGG</param>
         Task<PriceSingleResponse> SingleAsync(
             string fromSymbol,
             IEnumerable<string> toSymbols,

--- a/src/CryptoCompare/Clients/PricesClient.cs
+++ b/src/CryptoCompare/Clients/PricesClient.cs
@@ -57,7 +57,7 @@ namespace CryptoCompare
         /// <param name="calculationType">(Optional) Type of the calculation.</param>
         /// <param name="tryConversion">(Optional) If set to false, it will try to get values without
         /// using any conversion at all (defaultVal:true)</param>
-        /// <param name="exchangeName">(Optional) Exchange name default =&gt; CCCAGG.</param>
+        /// <param name="markets">(Optional) Names of Exchanges, default =&gt; CCCAGG.</param>
         /// <seealso cref="M:CryptoCompare.Clients.IPricesClient.Historical(string,IEnumerable{string},DateTimeOffset,CalculationType?,bool?,string)"/>
         public async Task<PriceHistoricalReponse> HistoricalAsync(
             [NotNull] string fromSymbol,
@@ -65,7 +65,7 @@ namespace CryptoCompare
             DateTimeOffset requestedDate,
             CalculationType? calculationType = null,
             bool? tryConversion = null,
-            string exchangeName = null)
+            IEnumerable<string> markets = null)
         {
             Check.NotNullOrWhiteSpace(fromSymbol, nameof(fromSymbol));
             Check.NotEmpty(toSymbols, nameof(toSymbols));
@@ -77,7 +77,33 @@ namespace CryptoCompare
                            requestedDate,
                            calculationType,
                            tryConversion,
-                           exchangeName)).ConfigureAwait(false);
+                           markets)).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Get the price of any cryptocurrency in any other currency that you need at a given timestamp.
+        /// The price comes from the daily info - so it would be the price at the end of the day GMT based on the requested TS.
+        /// If the crypto does not trade directly into the toSymbol requested, BTC will be used for conversion.
+        /// Tries to get direct trading pair data, if there is none or it is more than 10 days before the ts requested, it uses BTC conversion.
+        /// If the oposite pair trades we invert it (eg.: BTC-XMR)The calculation types are: Close - a Close of the day close price,MidHighLow - the average between the 24 H high and low.VolFVolT - the total volume to / the total volume from.
+        /// </summary>
+        /// <param name="fromSymbol">from symbol.</param>
+        /// <param name="toSymbols">to symbols.</param>
+        /// <param name="requestedDate">The requested date.</param>
+        /// <param name="calculationType">(Optional) Type of the calculation.</param>
+        /// <param name="tryConversion">(Optional) If set to false, it will try to get values without
+        /// using any conversion at all (defaultVal:true)</param>
+        /// <param name="market">(Optional) Exchange name, default =&gt; CCCAGG.</param>
+        /// <seealso cref="M:CryptoCompare.Clients.IPricesClient.Historical(string,IEnumerable{string},DateTimeOffset,CalculationType?,bool?,string)"/>
+        public async Task<PriceHistoricalReponse> HistoricalAsync(
+            [NotNull] string fromSymbol,
+            [NotNull] IEnumerable<string> toSymbols,
+            DateTimeOffset requestedDate,
+            CalculationType? calculationType = null,
+            bool? tryConversion = null,
+            string market = null)
+        {
+            return await this.HistoricalAsync(fromSymbol, toSymbols, requestedDate, calculationType, tryConversion, new [] { market });
         }
 
         /// <summary>
@@ -87,7 +113,7 @@ namespace CryptoCompare
         /// <param name="toSymbols">to symbols.</param>
         /// <param name="tryConversion">(Optional) If set to false, it will try to get values without
         /// using any conversion at all (defaultVal:true)</param>
-        /// <param name="exchangeName">(Optional) Exchange name defult =&gt; CCCAGG.</param>
+        /// <param name="exchangeName">(Optional) Exchange name default =&gt; CCCAGG.</param>
         /// <seealso cref="M:CryptoCompare.Clients.IPricesClient.Multi(IEnumerable{string},IEnumerable{string},bool?,string)"/>
         public async Task<PriceMultiResponse> MultiAsync(
             [NotNull] IEnumerable<string> fromSymbols,

--- a/src/CryptoCompare/Core/ApiUrls.cs
+++ b/src/CryptoCompare/Core/ApiUrls.cs
@@ -100,7 +100,7 @@ namespace CryptoCompare
             DateTimeOffset ts,
             CalculationType? calculationType,
             bool? tryConversion,
-            string e)
+            IEnumerable<string> markets)
         {
             return new Uri(MinApiEndpoint, "pricehistorical").ApplyParameters(
                 new Dictionary<string, string>
@@ -113,7 +113,7 @@ namespace CryptoCompare
                     },
                     { nameof(calculationType), calculationType?.ToString("G") },
                     { nameof(tryConversion), tryConversion?.ToString() },
-                    { nameof(e), e }
+                    { nameof(markets), markets.ToJoinedList() }
                 });
         }
 


### PR DESCRIPTION
- The 'e' parameter is no longer available for 'PriceHistorical', it
seems to have been replaced with 'markets' which is a list of multiple
exchange names. Updated to reflect this change. In the current NuGet
version (0.0.2) PriceHistorical does not work.
- Kept backwards compatibility by supplying an overload for
'HistoricalAsync'.
- Fixed some spelling mistakes