### PR TITLE
support for top volume on last 24h endpoint

### DIFF
--- a/src/CryptoCompare/Clients/ITopsClient.cs
+++ b/src/CryptoCompare/Clients/ITopsClient.cs
@@ -59,8 +59,20 @@ namespace CryptoCompare
         /// <param name="page">(Optional)The pagination for the request.</param>
         /// <param name="sign">(Optional)If set to true, the server will sign the requests, this is useful for usage in smart contracts.</param>
         /// <returns>
-        /// The asynchronous result that yields a CoinListResponse.
+        /// The asynchronous result that yields a TopMarketCapResponse.
         /// </returns>
         Task<TopMarketCapResponse> CoinFullDataByMarketCap([NotNull] string toSymbol, int? limit = null, int? page = null, bool? sign = null);
+
+        /// <summary>
+        /// Get full data for the top coins ordered by their total volume across all markets in the last 24 hours as expressed in a given currency.
+        /// </summary>
+        /// <param name="toSymbol">The symbol of the currency into which the market cap are expressed.</param>
+        /// <param name="limit">(Optional)The number currencies to return, default is 10.</param>
+        /// <param name="page">(Optional)The pagination for the request.</param>
+        /// <param name="sign">(Optional)If set to true, the server will sign the requests, this is useful for usage in smart contracts.</param>
+        /// <returns>
+        /// The asynchronous result that yields a TopVolume24HResponse.
+        /// </returns>
+        Task<TopVolume24HResponse> CoinFullDataBy24HVolume(string toSymbol, int? limit = null, int? page = null, bool? sign = null);
     }
 }

--- a/src/CryptoCompare/Clients/TopsClient.cs
+++ b/src/CryptoCompare/Clients/TopsClient.cs
@@ -103,13 +103,30 @@ namespace CryptoCompare
         /// <param name="page">(Optional)The pagination for the request.</param>
         /// <param name="sign">(Optional)If set to true, the server will sign the requests, this is useful for usage in smart contracts.</param>
         /// <returns>
-        /// The asynchronous result that yields a CoinListResponse.
+        /// The asynchronous result that yields a TopMarketCapResponse.
         /// </returns>
-        /// <seealso cref="M:CryptoCompare.ITopListClient.ExchangesFullDataByMarketCap(string,int?,int?,bool?)"/>
+        /// <seealso cref="M:CryptoCompare.ITopListClient.CoinFullDataByMarketCap(string,int?,int?,bool?)"/>
         public async Task<TopMarketCapResponse> CoinFullDataByMarketCap(string toSymbol, int? limit = null, int? page = null, bool? sign = null)
         {
             Check.NotNullOrWhiteSpace(toSymbol, nameof(toSymbol));
             return await this.GetAsync<TopMarketCapResponse>(ApiUrls.TopByMarketCapFull(toSymbol, limit, page, sign)).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Get full data for the top coins ordered by their total volume across all markets in the last 24 hours as expressed in a given currency.
+        /// </summary>
+        /// <param name="toSymbol">The symbol of the currency into which the market cap are expressed.</param>
+        /// <param name="limit">(Optional)The number currencies to return, default is 10.</param>
+        /// <param name="page">(Optional)The pagination for the request.</param>
+        /// <param name="sign">(Optional)If set to true, the server will sign the requests, this is useful for usage in smart contracts.</param>
+        /// <returns>
+        /// The asynchronous result that yields a TopVolume24HResponse.
+        /// </returns>
+        /// <seealso cref="M:CryptoCompare.ITopListClient.CoinFullDataBy24HVolume(string,int?,int?,bool?)"/>
+        public async Task<TopVolume24HResponse> CoinFullDataBy24HVolume(string toSymbol, int? limit = null, int? page = null, bool? sign = null)
+        {
+            Check.NotNullOrWhiteSpace(toSymbol, nameof(toSymbol));
+            return await this.GetAsync<TopVolume24HResponse>(ApiUrls.TopByVolume24HFull(toSymbol, limit, page, sign)).ConfigureAwait(false);
         }
     }
 }

--- a/src/CryptoCompare/Core/ApiUrls.cs
+++ b/src/CryptoCompare/Core/ApiUrls.cs
@@ -297,6 +297,19 @@ namespace CryptoCompare
                 });
         }
 
+        public static Uri TopByVolume24HFull([NotNull] string tsym, int? limit, int? page, bool? sign)
+        {
+            Check.NotNullOrWhiteSpace(tsym, nameof(tsym));
+            return new Uri(MinApiEndpoint, "top/totalvolfull").ApplyParameters(
+                new Dictionary<string, string>
+                {
+                    { nameof(tsym), tsym },
+                    { nameof(limit), limit?.ToString() },
+                    { nameof(page), page?.ToString() },
+                    { nameof(sign), sign?.ToString().ToLowerInvariant() }
+                });
+        }
+
         public static Uri TopByMarketCapFull([NotNull] string tsym, int? limit, int? page, bool? sign)
         {
             Check.NotNullOrWhiteSpace(tsym, nameof(tsym));

--- a/src/CryptoCompare/Models/Responses/TopVolume24HInfo.cs
+++ b/src/CryptoCompare/Models/Responses/TopVolume24HInfo.cs
@@ -1,0 +1,15 @@
+using Newtonsoft.Json;
+
+namespace CryptoCompare
+{
+    public class TopVolume24HInfo
+    {
+        public CoinInfo CoinInfo { get; set; }
+
+        [JsonProperty("DISPLAY")]
+        public Volume24HDisplay Display { get; set; }
+
+        [JsonProperty("RAW")]
+        public Volume24HRaw Raw { get; set; }
+    }
+}

--- a/src/CryptoCompare/Models/Responses/TopVolume24HResponse.cs
+++ b/src/CryptoCompare/Models/Responses/TopVolume24HResponse.cs
@@ -1,0 +1,11 @@
+﻿using System.Collections.Generic;
+
+using Newtonsoft.Json;
+
+namespace CryptoCompare
+{
+    public class TopVolume24HResponse : BaseApiResponse
+    {
+        public IReadOnlyList<TopVolume24HInfo> Data { get; set; }
+    }
+}

--- a/src/CryptoCompare/Models/Responses/Volume24HDisplay.cs
+++ b/src/CryptoCompare/Models/Responses/Volume24HDisplay.cs
@@ -1,0 +1,13 @@
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+
+namespace CryptoCompare
+{
+    public class Volume24HDisplay : ReadOnlyDictionary<string, CoinFullAggregatedDataDisplay>
+    {
+        public Volume24HDisplay(IDictionary<string, CoinFullAggregatedDataDisplay> dictionary)
+            : base(dictionary)
+        {
+        }
+    }
+}

--- a/src/CryptoCompare/Models/Responses/Volume24HRaw.cs
+++ b/src/CryptoCompare/Models/Responses/Volume24HRaw.cs
@@ -1,0 +1,13 @@
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+
+namespace CryptoCompare
+{
+    public class Volume24HRaw : ReadOnlyDictionary<string, CoinFullAggregatedData>
+    {
+        public Volume24HRaw(IDictionary<string, CoinFullAggregatedData> dictionary)
+            : base(dictionary)
+        {
+        }
+    }
+}

--- a/test/Cryptocompare.Integration.Tests/Clients/TopListClientTests.cs
+++ b/test/Cryptocompare.Integration.Tests/Clients/TopListClientTests.cs
@@ -42,5 +42,12 @@ namespace Cryptocompare.Integration.Tests.Clients
             var result = await CryptoCompareClient.Instance.Tops.CoinFullDataByMarketCap("EUR", 20);
             Assert.NotNull(result);
         }
+
+        [Fact]
+        public async Task CanCallTopListCoinFullDataBy24HVolume()
+        {
+            var result = await CryptoCompareClient.Instance.Tops.CoinFullDataBy24HVolume("EUR", 20);
+            Assert.NotNull(result);
+        }
     }
 }


### PR DESCRIPTION
# ↪️ Pull Request

Add support for the endpoint at https://min-api.cryptocompare.com/data/top/totalvolfull

## 💻 Examples

Just one more endpoint supported, nothing else :)

## 🚨 Test instructions

Debug the integration test provided to check that it works

## 💥 Does this PR introduce a breaking change?
- [X] No

## ✔️ PR Todo

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING.md](../../CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
