### PR TITLE
Throttle via handler

### DIFF
--- a/src/CryptoCompare/Core/ThottledHttpClientHandler.cs
+++ b/src/CryptoCompare/Core/ThottledHttpClientHandler.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace CryptoCompare
+{
+    public class ThottledHttpClientHandler : HttpClientHandler
+    {
+        private readonly SemaphoreSlim _semaphore;
+        private readonly int _millisecondsDelay;
+
+        /// <summary>
+        /// An <see cref="HttpClientHandler"></see> with a throttle to limit the maximum rate at which queries are sent.
+        /// </summary>
+        /// <param name="millisecondsDelay">The number of milliseconds to wait between calls to the base <see cref="HttpClientHandler.SendAsync"></see> method.</param>
+        /// <exception cref="T:System.ArgumentOutOfRangeException">The <paramref name="millisecondsDelay">millisecondsDelay</paramref> argument is less than or equal to 0.</exception>
+        public ThottledHttpClientHandler(int millisecondsDelay)
+        {
+            if (millisecondsDelay <= 0) throw new ArgumentOutOfRangeException(nameof(millisecondsDelay));
+
+            _millisecondsDelay = millisecondsDelay;
+            _semaphore = new SemaphoreSlim(1, 1);
+        }
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage requestMessage, CancellationToken cancellationToken)
+        {
+            Check.NotNull(requestMessage, nameof(requestMessage));
+
+            await _semaphore.WaitAsync(cancellationToken);
+            try
+            {
+                return await base.SendAsync(requestMessage, cancellationToken);
+            }
+            finally
+            {
+                await Task.Delay(_millisecondsDelay, cancellationToken);
+                _semaphore.Release(1);
+            }
+        }
+    }
+}

--- a/src/CryptoCompare/Core/ThottledHttpClientHandler.cs
+++ b/src/CryptoCompare/Core/ThottledHttpClientHandler.cs
@@ -17,7 +17,7 @@ namespace CryptoCompare
         /// <exception cref="T:System.ArgumentOutOfRangeException">The <paramref name="millisecondsDelay">millisecondsDelay</paramref> argument is less than or equal to 0.</exception>
         public ThottledHttpClientHandler(int millisecondsDelay)
         {
-            if (millisecondsDelay <= 0) throw new ArgumentOutOfRangeException(nameof(millisecondsDelay));
+            if (millisecondsDelay <= 0) { throw new ArgumentOutOfRangeException(nameof(millisecondsDelay)); }
 
             _millisecondsDelay = millisecondsDelay;
             _semaphore = new SemaphoreSlim(1, 1);
@@ -27,16 +27,27 @@ namespace CryptoCompare
         {
             Check.NotNull(requestMessage, nameof(requestMessage));
 
-            await _semaphore.WaitAsync(cancellationToken);
+            await _semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
             try
             {
                 return await base.SendAsync(requestMessage, cancellationToken);
             }
             finally
             {
-                await Task.Delay(_millisecondsDelay, cancellationToken);
+                await Task.Delay(_millisecondsDelay, cancellationToken).ConfigureAwait(false);
                 _semaphore.Release(1);
             }
+        }
+
+        /// <inheritdoc />
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                this._semaphore?.Dispose();
+            }
+
+            base.Dispose(disposing);
         }
     }
 }

--- a/src/CryptoCompare/CryptoCompareClient.cs
+++ b/src/CryptoCompare/CryptoCompareClient.cs
@@ -27,7 +27,7 @@ namespace CryptoCompare
         /// <param name="apiKey">The api key from cryptocompare</param>
         public CryptoCompareClient([NotNull] HttpClientHandler httpClientHandler, string apiKey = null)
         {
-            Check.NotNull(httpClientHandler, nameof(httpClientHandler));       
+            Check.NotNull(httpClientHandler, nameof(httpClientHandler));
             this._httpClient = new HttpClient(httpClientHandler, true);
 
             if (!string.IsNullOrWhiteSpace(apiKey))

--- a/src/CryptoCompare/CryptoCompareClient.cs
+++ b/src/CryptoCompare/CryptoCompareClient.cs
@@ -27,7 +27,7 @@ namespace CryptoCompare
         /// <param name="apiKey">The api key from cryptocompare</param>
         public CryptoCompareClient([NotNull] HttpClientHandler httpClientHandler, string apiKey = null)
         {
-            Check.NotNull(httpClientHandler, nameof(httpClientHandler));
+            Check.NotNull(httpClientHandler, nameof(httpClientHandler));       
             this._httpClient = new HttpClient(httpClientHandler, true);
 
             if (!string.IsNullOrWhiteSpace(apiKey))
@@ -39,8 +39,11 @@ namespace CryptoCompare
         /// <summary>
         /// Initializes a new instance of the CryptoCompare.CryptoCompareClient class.
         /// </summary>
-        public CryptoCompareClient(string apiKey = null)
-            : this(new HttpClientHandler(), apiKey)
+        /// /// <param name="throttleDelayMs">Delay imposed between each queries to avoid exceeding CryptoCompare's maximum number of requests per second.</param>
+        public CryptoCompareClient(string apiKey = null, int throttleDelayMs = 0)
+            : this(
+                throttleDelayMs <= 0 ? new HttpClientHandler() : new ThottledHttpClientHandler(throttleDelayMs),
+                apiKey)
         {
         }
 

--- a/test/Cryptocompare.Integration.Tests/Core/ThrottledHttpClientHandlerTests.cs
+++ b/test/Cryptocompare.Integration.Tests/Core/ThrottledHttpClientHandlerTests.cs
@@ -1,0 +1,35 @@
+﻿using System.Diagnostics;
+using System.Linq;
+using System.Threading.Tasks;
+
+using CryptoCompare;
+
+using Xunit;
+
+namespace Cryptocompare.Integration.Tests.Clients
+{
+    public class ThrottledHttpClientHandlerTests
+    {
+        [Fact]
+        public async Task WaitsBetweenQueries()
+        {
+            var throttleDelayMs = 200;
+            var queriesCount = 5;
+
+            var client = new CryptoCompareClient(throttleDelayMs: throttleDelayMs);
+
+            var stopWatch = new Stopwatch();
+            stopWatch.Start();
+
+            await Task.WhenAll(Enumerable.Repeat("start", queriesCount)
+               .Select(async _ => await client.RateLimits.CurrentHourAsync()));
+
+
+            stopWatch.Stop();
+
+            var minExpectedElapsedTime = queriesCount * throttleDelayMs;
+            Assert.True(stopWatch.ElapsedMilliseconds > minExpectedElapsedTime, $"Elapsed time should have been greater than {minExpectedElapsedTime}ms, but was {stopWatch.ElapsedMilliseconds}ms.");
+        }
+
+    }
+}


### PR DESCRIPTION
# ↪️ Pull Request
Closes https://github.com/joancaron/cryptocompare-api/issues/36

The aim of this new feature is to allow users to remain below the maximum number of requests per second imposed by CryptoCompare.com when using their API.

## 💻 Examples

For instance the free key I am using restricts the user to less than 10 requests per second.

## 🚨 Test instructions

cf. ThrottledHttpClientHandlerTests in the integration test project

## 💥 Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## ✔️ PR Todo

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING.md](../../CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
