### PR TITLE
add smart contract address on CoinInfo

### DIFF
--- a/src/CryptoCompare/Models/Responses/CoinInfo.cs
+++ b/src/CryptoCompare/Models/Responses/CoinInfo.cs
@@ -67,6 +67,11 @@
         /// Gets or sets the symbol.
         /// </summary>
         public string Symbol { get; set; }
+        
+        /// <summary>
+        /// Gets or sets the smart contract address.
+        /// </summary>
+        public string SmartContractAddress { get; set; }
 
         /// <summary>
         /// Gets or sets the total number of freed coins.

--- a/test/Cryptocompare.Integration.Tests/Clients/CoinsClientTests.cs
+++ b/test/Cryptocompare.Integration.Tests/Clients/CoinsClientTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System.Linq;
+using System.Threading.Tasks;
 
 using CryptoCompare;
 
@@ -13,6 +14,15 @@ namespace Cryptocompare.Integration.Tests.Clients
         {
             var result = await CryptoCompareClient.Instance.Coins.ListAsync();
             Assert.NotNull(result);
+        }
+
+        [Fact]
+        public async Task CanCallListEndpointAndRetrieveSmartContractAddresses()
+        {
+            var result = await CryptoCompareClient.Instance.Coins.ListAsync();
+            Assert.NotNull(result);
+            var foundSmartContractTokens = result.Coins.Any(c => c.Value.SmartContractAddress.StartsWith("0x"));
+            Assert.True(foundSmartContractTokens);
         }
 
         [Fact]


### PR DESCRIPTION
# ↪️ Pull Request
Add support for SmartContractAddress field in CoinInfo

## 💻 Examples
This field is available for ERC20 coins, for instance, the OMG token has
```
    "OMG": {
      "Id": "187440",
      "Url": "/coins/omg/overview",
      "ImageUrl": "/media/1383814/omisego.png",
      "ContentCreatedOn": 1500403271,
      "Name": "OMG",
      "Symbol": "OMG",
[...]
      "BuiltOn": "7605",
      "SmartContractAddress": "0xd26114cd6EE289AccF82350c8d8487fedB8A0C07",
      "PreMinedValue": "N/A",
      "TotalCoinsFreeFloat": "N/A",
[...]
    },
```

## 🚨 Test instructions
Added an integration test that checks the CoinList returns at least one with a contract that is not "N/A", null or empty.
It is a bit of a shame as this test is a bit long given the size of the response, and I could alternatively
1) add a check in the above test `CanCallListEndpoint` and delete my test
2) simply add a unit test that takes a hardcoded json and checks that the field is populated correctly

## 💥 Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## ✔️ PR Todo

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING.md](../../CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.


closes #61 